### PR TITLE
CPH1859 : selinux : Address proc_ged selinux denials

### DIFF
--- a/sepolicy/private/proc_ged.te
+++ b/sepolicy/private/proc_ged.te
@@ -1,0 +1,2 @@
+# Pretty much every graphics process need to access /proc/ged
+allowxperm domain proc_ged:file ioctl { 0x6700-0x67ff };


### PR DESCRIPTION
Address all proc_ged selinux denials like hal_graphics_composer_default, hal_graphics_allocator_default, surfaceflinger etc